### PR TITLE
Fix FramesCardholder interface

### DIFF
--- a/src/frames/types/types.tsx
+++ b/src/frames/types/types.tsx
@@ -79,9 +79,9 @@ export interface GatewayPhone {
 }
 
 export interface FramesCardholder {
-    name?: string;
-    billingAddress?: FramesBillingAddress;
-    phone?: string;
+    name: string | null;
+    billingAddress: FramesBillingAddress | null;
+    phone: string | null;
 }
 
 export interface FramesInitProps {


### PR DESCRIPTION
Frames initialises the `cardholder` object with all values set to `null` (see [checkout-frames-app/packages/frames-js/src/constants/defaultOptions.js#L18-L22](https://github.com/cko-payment-interfaces/checkout-frames-app/blob/fb05ac2/packages/frames-js/src/constants/defaultOptions.js#L18-L22)).

This PR updates the `FramesCardholder` interface to allow `null` for each property, and makes them non-optional since they will always be defined.